### PR TITLE
Wait for managed IDB closes during manager shutdown

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -487,7 +487,13 @@ IDA to unwind safely before abandoning the MCP request without a response.
 On stdio EOF, SIGINT, SIGTERM, or normal interpreter exit, the MCP server
 releases all handles. Other agents continue uninterrupted. If the released
 lease was the last lease on a managed worker, that worker performs its own
-shutdown. MCP and direct library leases remain indefinite unless they opt in.
+shutdown, and the server waits for that worker's IDB to finish closing before
+it exits: releasing a lease only asks the worker to pack, so returning early
+would let whatever stops this process kill a still-writing worker and leave a
+stale or truncated `.i64`. Handles are released concurrently and share one
+305-second drain budget, after which a wedged worker is reported as
+`database_release_error` and abandoned rather than blocking exit.
+MCP and direct library leases remain indefinite unless they opt in.
 The MCP accepts `--idle-timeout` or `IDA_NEXUS_MCP_IDLE_TIMEOUT`; zero disables
 idle release explicitly.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -487,13 +487,13 @@ IDA to unwind safely before abandoning the MCP request without a response.
 On stdio EOF, SIGINT, SIGTERM, or normal interpreter exit, the MCP server
 releases all handles. Other agents continue uninterrupted. If the released
 lease was the last lease on a managed worker, that worker performs its own
-shutdown, and the server waits for that worker's IDB to finish closing before
-it exits: releasing a lease only asks the worker to pack, so returning early
-would let whatever stops this process kill a still-writing worker and leave a
-stale or truncated `.i64`. Handles are released concurrently and share one
-305-second drain budget, after which a wedged worker is reported as
-`database_release_error` and abandoned rather than blocking exit.
-MCP and direct library leases remain indefinite unless they opt in.
+shutdown, and the server waits for that worker's IDB to finish closing:
+releasing a lease only asks the worker to pack, so exiting first would let
+whatever stops this process kill a still-writing worker and leave a stale or
+truncated `.i64`. Handles are released concurrently under one 305-second
+budget; a worker that overruns it is reported and abandoned rather than
+blocking exit. MCP and direct library leases remain indefinite unless they
+opt in.
 The MCP accepts `--idle-timeout` or `IDA_NEXUS_MCP_IDLE_TIMEOUT`; zero disables
 idle release explicitly.
 

--- a/ida_nexus/manager.py
+++ b/ida_nexus/manager.py
@@ -35,9 +35,6 @@ from ida_nexus.options import MAX_KEEPALIVE_SECONDS, DatabaseOpenOptions
 
 DEFAULT_OPEN_TIMEOUT_SECONDS = 300.0
 DEFAULT_EXECUTE_TIMEOUT_SECONDS = 360.0
-# Concurrent shutdown releases are bounded by the shared close deadline; this
-# grace only covers each handle's own lease-thread join and socket teardown.
-SHUTDOWN_JOIN_GRACE_SECONDS = 5.0
 
 
 DatabaseEventCallback = Callable[[str, dict[str, Any]], None]
@@ -634,31 +631,15 @@ class DatabaseManager:
         )
         return CloseDatabaseResult(closed=True)
 
-    def _release_for_shutdown(self, session: _DatabaseSession, deadline: float) -> None:
-        try:
-            session.handle.close(
-                wait_for_database=True,
-                timeout=max(0.0, deadline - time.monotonic()),
-            )
-        except Exception as error:  # noqa: BLE001 -- best-effort shutdown reporting
-            self._emit(
-                "database_release_error",
-                instance_id=session.instance_id,
-                error=error,
-            )
-
     def shutdown(self, *, timeout: float = DATABASE_CLOSE_TIMEOUT_SECONDS) -> None:
-        """Release every handle, waiting for final managed IDB closes.
+        """Release every handle and wait for final managed IDB closes.
 
-        Process shutdown is a managed worker's last chance to pack its IDB, and
-        releasing a lease only asks the worker to start closing. Whatever stops
-        this process (a service replacement, a restarted host) may kill the
-        still-writing worker moments later, so drain those closes here instead
-        of returning while packs are in flight and leaving a stale or truncated
-        ``.i64`` behind. ``timeout`` bounds the whole drain, after which a
-        wedged worker is reported and abandoned rather than blocking exit.
+        Releasing a lease only asks the worker to start packing its IDB, and
+        whatever stops this process may kill that worker moments later, leaving
+        a stale or truncated ``.i64``. Every handle is released under one shared
+        ``timeout`` budget; a worker that overruns it is reported as
+        ``database_release_error`` instead of blocking exit.
         """
-
         if (
             isinstance(timeout, bool)
             or not isinstance(timeout, (int, float))
@@ -678,17 +659,30 @@ class DatabaseManager:
         if not sessions:
             return
         deadline = time.monotonic() + float(timeout)
+
+        def _release(session: _DatabaseSession) -> None:
+            try:
+                session.handle.close(
+                    wait_for_database=True,
+                    timeout=max(0.0, deadline - time.monotonic()),
+                )
+            except Exception as error:  # noqa: BLE001 -- best-effort shutdown reporting
+                self._emit(
+                    "database_release_error",
+                    instance_id=session.instance_id,
+                    error=error,
+                )
+
         if len(sessions) == 1:
-            self._release_for_shutdown(sessions[0], deadline)
+            _release(sessions[0])
             return
-        # Each worker packs its own IDB, so spend the shutdown budget on all of
-        # them at once. Draining sequentially would strand the last database in
-        # exactly the position this wait exists to fix.
+        # Each worker packs its own IDB, so release them at once: draining one
+        # after another would spend the budget before reaching the last one.
         threads = [
             threading.Thread(
-                target=self._release_for_shutdown,
-                args=(session, deadline),
-                name=f"nexus-shutdown-{session.instance_id}",
+                target=_release,
+                args=(session,),
+                name=f"shutdown-release-{session.instance_id}",
                 daemon=True,
             )
             for session in sessions
@@ -696,6 +690,4 @@ class DatabaseManager:
         for thread in threads:
             thread.start()
         for thread in threads:
-            thread.join(
-                max(0.0, deadline - time.monotonic()) + SHUTDOWN_JOIN_GRACE_SECONDS
-            )
+            thread.join()

--- a/ida_nexus/manager.py
+++ b/ida_nexus/manager.py
@@ -164,7 +164,10 @@ class DatabaseManager:
         self._disconnected_default: str | None = None
         self._current_instance_id: str | None = None
         self._lock = threading.RLock()
-        self._open_lock = threading.Lock()
+        # Shutdown takes the same lock so a handle cannot be created between
+        # its session snapshot and the manager becoming terminal. Keep this
+        # reentrant because an open event callback may itself request shutdown.
+        self._open_lock = threading.RLock()
         self._shutdown_started = False
         # Background thread from a scheduled startup open, if any. Operations
         # that need the current database wait on it so they do not race the
@@ -647,7 +650,11 @@ class DatabaseManager:
             or timeout < 0
         ):
             raise ValueError("timeout must be a finite non-negative number")
-        with self._lock:
+        # An open holds _open_lock from its initial shutdown check until its
+        # handle is installed. Waiting here makes that handle part of this
+        # snapshot; taking the lock first also prevents later opens from
+        # slipping past the terminal-state transition.
+        with self._open_lock, self._lock:
             if self._shutdown_started:
                 return
             self._shutdown_started = True

--- a/ida_nexus/manager.py
+++ b/ida_nexus/manager.py
@@ -7,6 +7,7 @@ error presentation, request metadata, and tracing belong to those adapters.
 
 import math
 import threading
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -28,12 +29,15 @@ from ida_nexus.errors import (
     NexusConnectionError,
     NexusError,
 )
-from ida_nexus.handle import DatabaseHandle
+from ida_nexus.handle import DATABASE_CLOSE_TIMEOUT_SECONDS, DatabaseHandle
 from ida_nexus.models import PythonExecutionResult
 from ida_nexus.options import MAX_KEEPALIVE_SECONDS, DatabaseOpenOptions
 
 DEFAULT_OPEN_TIMEOUT_SECONDS = 300.0
 DEFAULT_EXECUTE_TIMEOUT_SECONDS = 360.0
+# Concurrent shutdown releases are bounded by the shared close deadline; this
+# grace only covers each handle's own lease-thread join and socket teardown.
+SHUTDOWN_JOIN_GRACE_SECONDS = 5.0
 
 
 DatabaseEventCallback = Callable[[str, dict[str, Any]], None]
@@ -630,7 +634,38 @@ class DatabaseManager:
         )
         return CloseDatabaseResult(closed=True)
 
-    def shutdown(self) -> None:
+    def _release_for_shutdown(self, session: _DatabaseSession, deadline: float) -> None:
+        try:
+            session.handle.close(
+                wait_for_database=True,
+                timeout=max(0.0, deadline - time.monotonic()),
+            )
+        except Exception as error:  # noqa: BLE001 -- best-effort shutdown reporting
+            self._emit(
+                "database_release_error",
+                instance_id=session.instance_id,
+                error=error,
+            )
+
+    def shutdown(self, *, timeout: float = DATABASE_CLOSE_TIMEOUT_SECONDS) -> None:
+        """Release every handle, waiting for final managed IDB closes.
+
+        Process shutdown is a managed worker's last chance to pack its IDB, and
+        releasing a lease only asks the worker to start closing. Whatever stops
+        this process (a service replacement, a restarted host) may kill the
+        still-writing worker moments later, so drain those closes here instead
+        of returning while packs are in flight and leaving a stale or truncated
+        ``.i64`` behind. ``timeout`` bounds the whole drain, after which a
+        wedged worker is reported and abandoned rather than blocking exit.
+        """
+
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(timeout)
+            or timeout < 0
+        ):
+            raise ValueError("timeout must be a finite non-negative number")
         with self._lock:
             if self._shutdown_started:
                 return
@@ -640,12 +675,27 @@ class DatabaseManager:
             self._disconnected_instances.clear()
             self._disconnected_default = None
             self._current_instance_id = None
-        for session in sessions:
-            try:
-                session.handle.close()
-            except Exception as error:  # noqa: BLE001 -- best-effort shutdown reporting
-                self._emit(
-                    "database_release_error",
-                    instance_id=session.instance_id,
-                    error=error,
-                )
+        if not sessions:
+            return
+        deadline = time.monotonic() + float(timeout)
+        if len(sessions) == 1:
+            self._release_for_shutdown(sessions[0], deadline)
+            return
+        # Each worker packs its own IDB, so spend the shutdown budget on all of
+        # them at once. Draining sequentially would strand the last database in
+        # exactly the position this wait exists to fix.
+        threads = [
+            threading.Thread(
+                target=self._release_for_shutdown,
+                args=(session, deadline),
+                name=f"nexus-shutdown-{session.instance_id}",
+                daemon=True,
+            )
+            for session in sessions
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(
+                max(0.0, deadline - time.monotonic()) + SHUTDOWN_JOIN_GRACE_SECONDS
+            )

--- a/tests/test_idalib_e2e.py
+++ b/tests/test_idalib_e2e.py
@@ -1,0 +1,84 @@
+import os
+import shutil
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ida_nexus import DatabaseHandle, DatabaseManager, wait_database_released
+
+_RUN_IDALIB_E2E = os.environ.get("IDA_NEXUS_RUN_IDALIB_E2E") == "1"
+
+
+@pytest.mark.skipif(
+    not _RUN_IDALIB_E2E,
+    reason="set IDA_NEXUS_RUN_IDALIB_E2E=1 to run real idalib lifecycle tests",
+)
+def test_shutdown_waits_for_in_flight_real_idalib_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Shutdown must include a real worker whose open has not been installed yet."""
+    executable = tmp_path / "python.exe"
+    shutil.copyfile(sys.executable, executable)
+
+    handle_opened = threading.Event()
+    allow_open_to_finish = threading.Event()
+    shutdown_finished = threading.Event()
+    worker_instances: list[Any] = []
+    open_errors: list[BaseException] = []
+    shutdown_errors: list[BaseException] = []
+    real_open = DatabaseHandle.open
+
+    def blocked_open(
+        cls: type[DatabaseHandle],
+        path: str,
+        *,
+        options=None,
+        on_disconnect=None,
+    ) -> DatabaseHandle:
+        del cls
+        handle = real_open(path, options=options, on_disconnect=on_disconnect)
+        worker_instances.append(handle.instance)
+        handle_opened.set()
+        assert allow_open_to_finish.wait(10)
+        return handle
+
+    monkeypatch.setattr(DatabaseHandle, "open", classmethod(blocked_open))
+    manager = DatabaseManager(open_timeout=120)
+
+    def open_database() -> None:
+        try:
+            manager.open_database(str(executable), set_current=True)
+        except BaseException as error:  # noqa: BLE001 -- asserted by the test
+            open_errors.append(error)
+
+    def shutdown() -> None:
+        try:
+            manager.shutdown(timeout=30)
+        except BaseException as error:  # noqa: BLE001 -- asserted by the test
+            shutdown_errors.append(error)
+        finally:
+            shutdown_finished.set()
+
+    open_thread = threading.Thread(target=open_database, name="e2e-open")
+    shutdown_thread = threading.Thread(target=shutdown, name="e2e-shutdown")
+    open_thread.start()
+    try:
+        assert handle_opened.wait(120), "real idalib worker did not open"
+        shutdown_thread.start()
+        returned_before_open_finished = shutdown_finished.wait(0.5)
+    finally:
+        allow_open_to_finish.set()
+
+    open_thread.join(120)
+    shutdown_thread.join(120)
+
+    assert not returned_before_open_finished
+    assert not open_thread.is_alive()
+    assert not shutdown_thread.is_alive()
+    assert open_errors == []
+    assert shutdown_errors == []
+    assert worker_instances
+    assert wait_database_released(worker_instances[0], timeout=10)

--- a/tests/test_instance_management.py
+++ b/tests/test_instance_management.py
@@ -1424,11 +1424,15 @@ def test_get_session_waits_for_in_flight_startup_open(tmp_path: Path) -> None:
     assert session is sentinel
 
 
-def test_shutdown_during_open_releases_the_late_handle(monkeypatch) -> None:
+def test_shutdown_waits_for_in_flight_open_and_releases_handle(monkeypatch) -> None:
     open_started = threading.Event()
     finish_open = threading.Event()
     handle_closed = threading.Event()
+    shutdown_started = threading.Event()
+    shutdown_finished = threading.Event()
     failures: list[Exception] = []
+    shutdown_failures: list[Exception] = []
+    close_options: dict[str, Any] = {}
 
     entry = DatabaseInstance(
         record_id="123-abcdef",
@@ -1448,6 +1452,7 @@ def test_shutdown_during_open_releases_the_late_handle(monkeypatch) -> None:
         def __init__(self) -> None:
             self.instance = entry
             self.disconnect_reason = None
+            self.recovery = "none"
             self._connected = True
 
         @property
@@ -1457,13 +1462,14 @@ def test_shutdown_during_open_releases_the_late_handle(monkeypatch) -> None:
         def set_disconnect_callback(self, _callback) -> None:
             pass
 
-        def close(self) -> None:
+        def close(self, **kwargs) -> None:
+            close_options.update(kwargs)
             self._connected = False
             handle_closed.set()
 
     @classmethod
     def slow_open(cls, path: str, **kwargs) -> SlowHandle:
-        assert path.endswith("/tmp/test")
+        del cls, path
         assert kwargs["options"].auto_analysis is True
         open_started.set()
         assert finish_open.wait(2)
@@ -1478,20 +1484,33 @@ def test_shutdown_during_open_releases_the_late_handle(monkeypatch) -> None:
         except Exception as exc:  # noqa: BLE001 - captured for the assertion
             failures.append(exc)
 
-    thread = threading.Thread(target=open_database)
-    thread.start()
+    def shutdown() -> None:
+        shutdown_started.set()
+        try:
+            manager.shutdown()
+        except Exception as exc:  # noqa: BLE001 - captured for the assertion
+            shutdown_failures.append(exc)
+        finally:
+            shutdown_finished.set()
+
+    open_thread = threading.Thread(target=open_database)
+    shutdown_thread = threading.Thread(target=shutdown)
+    open_thread.start()
     assert open_started.wait(1)
 
-    # Reproduction: shutdown completes while handle creation is still blocked.
-    manager.shutdown()
+    shutdown_thread.start()
+    assert shutdown_started.wait(1)
+    assert not shutdown_finished.wait(0.1)
     finish_open.set()
-    thread.join(2)
+    open_thread.join(2)
+    shutdown_thread.join(2)
 
-    assert not thread.is_alive()
+    assert not open_thread.is_alive()
+    assert not shutdown_thread.is_alive()
     assert handle_closed.is_set()
-    assert len(failures) == 1
-    assert isinstance(failures[0], DatabaseSelectionError)
-    assert "shutting down" in str(failures[0])
+    assert close_options["wait_for_database"] is True
+    assert failures == []
+    assert shutdown_failures == []
     assert manager._instances == {}
 
 

--- a/tests/test_instance_management.py
+++ b/tests/test_instance_management.py
@@ -2418,8 +2418,6 @@ def test_cancel_active_preserves_database_handle(tmp_path: Path) -> None:
         AnalysisState(),
         REGISTRY_DIR,
         lease_grace=30,
-        # Model the worker's lifetime-lock release after its IDB closes, which
-        # manager.shutdown() waits for.
         on_shutdown=lambda: server.release_registration(),
     )
     server.start()
@@ -2521,55 +2519,45 @@ def test_manager_shutdown_waits_for_final_managed_idb_close(tmp_path: Path) -> N
         on_shutdown=finish_shutdown,
     )
     server.start()
-    manager = DatabaseManager()
-    manager.open_database(str(idb), set_current=True)
     events: list[tuple[str, dict[str, Any]]] = []
-    manager._on_event = lambda event, fields: events.append((event, fields))
-    finished = threading.Event()
+    manager = DatabaseManager(
+        on_event=lambda event, fields: events.append((event, fields))
+    )
+    manager.open_database(str(idb), set_current=True)
 
-    def shutdown() -> None:
-        manager.shutdown()
-        finished.set()
-
-    thread = threading.Thread(target=shutdown)
+    thread = threading.Thread(target=manager.shutdown)
     thread.start()
     assert shutdown_started.wait(1)
-    assert not finished.wait(0.2)
+    assert thread.is_alive()
     idb_closed.set()
     thread.join(2)
 
     assert not thread.is_alive()
-    assert finished.is_set()
-    assert events == []
+    assert [event for event, _fields in events] == ["database_opened"]
     server.stop()
     server.release_registration()
 
 
 def test_manager_shutdown_drains_databases_concurrently(tmp_path: Path) -> None:
-    # Workers pack their own IDBs, so the shutdown budget is spent on all of
-    # them at once. A serial drain could not reach the second worker until the
-    # first one finished, which is how the last database used to lose its pack.
+    # Each worker packs its own IDB, so both releases must be in flight at once.
+    # A serial drain could not reach the second worker while the first one is
+    # still packing, which is how the last database would lose its pack.
     release = threading.Event()
-    both_started = threading.Event()
-    started_lock = threading.Lock()
-    started: list[str] = []
+    servers: dict[str, NexusHTTPServer] = {}
+    packing = {name: threading.Event() for name in ("first", "second")}
 
-    def start_worker(name: str) -> NexusHTTPServer:
+    def start_worker(name: str) -> None:
         idb = tmp_path / f"{name}.i64"
         executable = tmp_path / f"{name}.exe"
         idb.write_bytes(b"idb")
         executable.write_bytes(b"binary")
-        holder: list[NexusHTTPServer] = []
 
         def on_shutdown() -> None:
-            with started_lock:
-                started.append(name)
-                if len(started) == 2:
-                    both_started.set()
+            packing[name].set()
             assert release.wait(3)
-            holder[0].release_registration()
+            servers[name].release_registration()
 
-        server = NexusHTTPServer(
+        servers[name] = NexusHTTPServer(
             StaticBackend(),
             InstanceIdentity(str(idb), str(executable), "idalib", managed=True),
             AnalysisState(),
@@ -2577,41 +2565,37 @@ def test_manager_shutdown_drains_databases_concurrently(tmp_path: Path) -> None:
             lease_grace=30,
             on_shutdown=on_shutdown,
         )
-        holder.append(server)
-        server.start()
-        return server
+        servers[name].start()
 
-    first = start_worker("first")
-    second = start_worker("second")
-    manager = DatabaseManager()
-    manager.open_database(str(tmp_path / "first.i64"), set_current=True)
-    manager.open_database(str(tmp_path / "second.i64"), set_current=False)
     events: list[tuple[str, dict[str, Any]]] = []
-    manager._on_event = lambda event, fields: events.append((event, fields))
-    finished = threading.Event()
+    manager = DatabaseManager(
+        on_event=lambda event, fields: events.append((event, fields))
+    )
+    for name in packing:
+        start_worker(name)
+        manager.open_database(str(tmp_path / f"{name}.i64"), set_current=True)
 
-    def shutdown() -> None:
-        manager.shutdown()
-        finished.set()
-
-    thread = threading.Thread(target=shutdown)
+    thread = threading.Thread(target=manager.shutdown)
     thread.start()
-    assert both_started.wait(2)
-    assert not finished.wait(0.2)
+    assert packing["first"].wait(2)
+    assert packing["second"].wait(2)
+    assert thread.is_alive()
     release.set()
     thread.join(3)
 
     assert not thread.is_alive()
-    assert finished.is_set()
-    assert events == []
-    for server in (first, second):
+    assert [event for event, _fields in events] == [
+        "database_opened",
+        "database_opened",
+    ]
+    for server in servers.values():
         server.stop()
         server.release_registration()
 
 
 def test_manager_shutdown_reports_a_wedged_final_idb_close(tmp_path: Path) -> None:
-    # A worker that never finishes its pack must not block process exit forever;
-    # the bounded wait reports the timeout and abandons it.
+    # A worker that never finishes its pack must not hold up process exit; the
+    # bounded wait reports the timeout and abandons it.
     executable = tmp_path / "test.exe"
     idb = tmp_path / "test.i64"
     executable.write_bytes(b"binary")
@@ -2626,36 +2610,27 @@ def test_manager_shutdown_reports_a_wedged_final_idb_close(tmp_path: Path) -> No
         on_shutdown=lambda: None,
     )
     server.start()
-    manager = DatabaseManager()
-    opened = manager.open_database(str(idb), set_current=True)
     events: list[tuple[str, dict[str, Any]]] = []
-    manager._on_event = lambda event, fields: events.append((event, fields))
+    manager = DatabaseManager(
+        on_event=lambda event, fields: events.append((event, fields))
+    )
+    opened = manager.open_database(str(idb), set_current=True)
 
     started = time.monotonic()
     manager.shutdown(timeout=0.25)
-    elapsed = time.monotonic() - started
 
-    assert elapsed < 2
-    assert [event for event, _fields in events] == ["database_release_error"]
-    fields = events[0][1]
+    assert time.monotonic() - started < 2
+    assert [event for event, _fields in events] == [
+        "database_opened",
+        "database_release_error",
+    ]
+    fields = events[-1][1]
     assert fields["instance_id"] == opened["instance_id"]
     assert isinstance(fields["error"], NexusConnectionError)
     assert "waiting for the IDB to close" in str(fields["error"])
     assert manager._instances == {}
     server.stop()
     server.release_registration()
-
-
-def test_manager_shutdown_rejects_an_invalid_timeout() -> None:
-    manager = DatabaseManager()
-    for timeout in (-1.0, float("nan"), True, "5"):
-        try:
-            manager.shutdown(timeout=timeout)  # type: ignore[arg-type]
-        except ValueError as exc:
-            assert "finite non-negative" in str(exc)
-        else:  # pragma: no cover
-            raise AssertionError(f"accepted invalid timeout: {timeout!r}")
-    manager.shutdown()
 
 
 def test_database_close_cancels_its_active_execution(tmp_path: Path) -> None:

--- a/tests/test_instance_management.py
+++ b/tests/test_instance_management.py
@@ -20,6 +20,7 @@ from ida_nexus import (
     DatabaseManager,
     DatabaseOpenOptions,
     DatabaseSelectionError,
+    NexusConnectionError,
     PythonExecutionResult,
     discover_databases,
     find_database_owner,
@@ -2417,7 +2418,9 @@ def test_cancel_active_preserves_database_handle(tmp_path: Path) -> None:
         AnalysisState(),
         REGISTRY_DIR,
         lease_grace=30,
-        on_shutdown=lambda: None,
+        # Model the worker's lifetime-lock release after its IDB closes, which
+        # manager.shutdown() waits for.
+        on_shutdown=lambda: server.release_registration(),
     )
     server.start()
     manager = DatabaseManager()
@@ -2491,6 +2494,168 @@ def test_manager_close_waits_for_final_managed_idb_close(tmp_path: Path) -> None
     assert failures == []
     server.stop()
     server.release_registration()
+
+
+def test_manager_shutdown_waits_for_final_managed_idb_close(tmp_path: Path) -> None:
+    # Regression: process shutdown must drain the worker's final pack. Returning
+    # while the IDB is still being written leaves a stale or truncated .i64
+    # behind when whatever stops this process also kills the worker.
+    executable = tmp_path / "test.exe"
+    idb = tmp_path / "test.i64"
+    executable.write_bytes(b"binary")
+    idb.write_bytes(b"idb")
+    shutdown_started = threading.Event()
+    idb_closed = threading.Event()
+
+    def finish_shutdown() -> None:
+        shutdown_started.set()
+        assert idb_closed.wait(2)
+        server.release_registration()
+
+    server = NexusHTTPServer(
+        StaticBackend(),
+        InstanceIdentity(str(idb), str(executable), "idalib", managed=True),
+        AnalysisState(),
+        REGISTRY_DIR,
+        lease_grace=30,
+        on_shutdown=finish_shutdown,
+    )
+    server.start()
+    manager = DatabaseManager()
+    manager.open_database(str(idb), set_current=True)
+    events: list[tuple[str, dict[str, Any]]] = []
+    manager._on_event = lambda event, fields: events.append((event, fields))
+    finished = threading.Event()
+
+    def shutdown() -> None:
+        manager.shutdown()
+        finished.set()
+
+    thread = threading.Thread(target=shutdown)
+    thread.start()
+    assert shutdown_started.wait(1)
+    assert not finished.wait(0.2)
+    idb_closed.set()
+    thread.join(2)
+
+    assert not thread.is_alive()
+    assert finished.is_set()
+    assert events == []
+    server.stop()
+    server.release_registration()
+
+
+def test_manager_shutdown_drains_databases_concurrently(tmp_path: Path) -> None:
+    # Workers pack their own IDBs, so the shutdown budget is spent on all of
+    # them at once. A serial drain could not reach the second worker until the
+    # first one finished, which is how the last database used to lose its pack.
+    release = threading.Event()
+    both_started = threading.Event()
+    started_lock = threading.Lock()
+    started: list[str] = []
+
+    def start_worker(name: str) -> NexusHTTPServer:
+        idb = tmp_path / f"{name}.i64"
+        executable = tmp_path / f"{name}.exe"
+        idb.write_bytes(b"idb")
+        executable.write_bytes(b"binary")
+        holder: list[NexusHTTPServer] = []
+
+        def on_shutdown() -> None:
+            with started_lock:
+                started.append(name)
+                if len(started) == 2:
+                    both_started.set()
+            assert release.wait(3)
+            holder[0].release_registration()
+
+        server = NexusHTTPServer(
+            StaticBackend(),
+            InstanceIdentity(str(idb), str(executable), "idalib", managed=True),
+            AnalysisState(),
+            REGISTRY_DIR,
+            lease_grace=30,
+            on_shutdown=on_shutdown,
+        )
+        holder.append(server)
+        server.start()
+        return server
+
+    first = start_worker("first")
+    second = start_worker("second")
+    manager = DatabaseManager()
+    manager.open_database(str(tmp_path / "first.i64"), set_current=True)
+    manager.open_database(str(tmp_path / "second.i64"), set_current=False)
+    events: list[tuple[str, dict[str, Any]]] = []
+    manager._on_event = lambda event, fields: events.append((event, fields))
+    finished = threading.Event()
+
+    def shutdown() -> None:
+        manager.shutdown()
+        finished.set()
+
+    thread = threading.Thread(target=shutdown)
+    thread.start()
+    assert both_started.wait(2)
+    assert not finished.wait(0.2)
+    release.set()
+    thread.join(3)
+
+    assert not thread.is_alive()
+    assert finished.is_set()
+    assert events == []
+    for server in (first, second):
+        server.stop()
+        server.release_registration()
+
+
+def test_manager_shutdown_reports_a_wedged_final_idb_close(tmp_path: Path) -> None:
+    # A worker that never finishes its pack must not block process exit forever;
+    # the bounded wait reports the timeout and abandons it.
+    executable = tmp_path / "test.exe"
+    idb = tmp_path / "test.i64"
+    executable.write_bytes(b"binary")
+    idb.write_bytes(b"idb")
+    server = NexusHTTPServer(
+        StaticBackend(),
+        InstanceIdentity(str(idb), str(executable), "idalib", managed=True),
+        AnalysisState(),
+        REGISTRY_DIR,
+        lease_grace=30,
+        # The worker accepts the release but never releases its lifetime lock.
+        on_shutdown=lambda: None,
+    )
+    server.start()
+    manager = DatabaseManager()
+    opened = manager.open_database(str(idb), set_current=True)
+    events: list[tuple[str, dict[str, Any]]] = []
+    manager._on_event = lambda event, fields: events.append((event, fields))
+
+    started = time.monotonic()
+    manager.shutdown(timeout=0.25)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 2
+    assert [event for event, _fields in events] == ["database_release_error"]
+    fields = events[0][1]
+    assert fields["instance_id"] == opened["instance_id"]
+    assert isinstance(fields["error"], NexusConnectionError)
+    assert "waiting for the IDB to close" in str(fields["error"])
+    assert manager._instances == {}
+    server.stop()
+    server.release_registration()
+
+
+def test_manager_shutdown_rejects_an_invalid_timeout() -> None:
+    manager = DatabaseManager()
+    for timeout in (-1.0, float("nan"), True, "5"):
+        try:
+            manager.shutdown(timeout=timeout)  # type: ignore[arg-type]
+        except ValueError as exc:
+            assert "finite non-negative" in str(exc)
+        else:  # pragma: no cover
+            raise AssertionError(f"accepted invalid timeout: {timeout!r}")
+    manager.shutdown()
 
 
 def test_database_close_cancels_its_active_execution(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #50.

## Problem

`DatabaseManager.shutdown()` released every lease without waiting. Releasing a lease only asks a managed worker to start packing its IDB, so the MCP process exited while the pack was still in flight — and whatever stops the process (a service replacement during a reprovisioning upgrade, a restarted host) may kill or freeze the still-writing worker moments later. The result is a stale or truncated `.i64` that the next `open_database` silently loads.

The waiting paths already got this right: `close_database` passes `wait_for_database=True`, and the idle timeout is safe by construction because the worker itself decides when to exit.

## Change

`shutdown()` now closes each handle with `wait_for_database=True` under a `timeout` budget (default `DATABASE_CLOSE_TIMEOUT_SECONDS`, the 305 seconds `close_database` already documents), so SIGTERM, SIGINT, stdio EOF, and interpreter exit drain the final packs.

- One shared deadline covers the whole drain. A worker that overruns it is reported as `database_release_error` and abandoned rather than blocking exit.
- With more than one open database the releases run concurrently: each worker packs its own IDB, so draining one after another would spend the budget before reaching the last database — exactly the state this wait prevents. A single session, the common case, closes on the calling thread.
- `test_cancel_active_preserves_database_handle` now models the worker's lifetime-lock release like the neighboring close test; its fake never released the lock and so would sit in the new drain.

## Tests

- `test_manager_shutdown_waits_for_final_managed_idb_close` — shutdown blocks until the worker releases its lifetime lock.
- `test_manager_shutdown_drains_databases_concurrently` — both workers must be packing at once before either is allowed to finish; verified this fails against a serial drain.
- `test_manager_shutdown_reports_a_wedged_final_idb_close` — a worker that never releases yields one `database_release_error` and a prompt return.

`docs/ARCHITECTURE.md` records the drain in the MCP lifecycle section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019g4HHxapXmH6QxN17ct1uP